### PR TITLE
Bugfix for bounding boxes dragging, and minor bugfix for image select

### DIFF
--- a/frontend/src/Project.js
+++ b/frontend/src/Project.js
@@ -509,7 +509,7 @@ class Project extends Component {
 
   handleImageSelection = currentImageIndex => {
     // sync before changing image if necessary
-    this.syncCurrentTagsDB().then(this.getTags())
+    this.syncCurrentTagsDB().then(this.getTags)
     this.setState({ currentImageIndex })
   }
 

--- a/frontend/src/Tagger.js
+++ b/frontend/src/Tagger.js
@@ -8,7 +8,11 @@ import './Tagger.css'
 
 class Tagger extends React.Component {
   addBoundingBoxes = () => {
-    Object.values(this._boundingBoxes).forEach(boundingBox => boundingBox.remove())
+    Object.values(this._boundingBoxes).forEach(boundingBox => {
+      boundingBox.setDraggable(false)
+      boundingBox.getChildren(element => element.setDraggable(false))
+      boundingBox.remove()
+    })
     this._boundingBoxes = {}
 
     this.props.image.tags.forEach(({ x, y, width, height, label, id }) => {


### PR DESCRIPTION
When the user is dragging a box, the POST for tags update is not
executed.
But if the user started dragging just after the request was already
initiated, the response to getTags would cause an update of the bounding
boxes that caused a Konva crash because the bboxes were removed while
being dragged.