### PR TITLE
Expose ports in Dockerfile's

### DIFF
--- a/deploy/api.docker
+++ b/deploy/api.docker
@@ -19,3 +19,5 @@ COPY api /api
 RUN pip install -r api/requirements.txt
 
 CMD uwsgi --ini /api/api.ini
+
+EXPOSE 5000

--- a/deploy/frontend.docker
+++ b/deploy/frontend.docker
@@ -17,3 +17,5 @@ COPY frontend /src/app
 
 # defined in package.json
 CMD [ "yarn", "start"]
+
+EXPOSE 3000


### PR DESCRIPTION
[Exposes](https://docs.docker.com/engine/reference/builder/#expose) the ports in the REST API and frontend Dockerfile's so another tool such as [nginx-proxy](https://github.com/jwilder/nginx-proxy) can read it (and also other containers can directly connect to them in the same network).

Btw, this is a great tool!